### PR TITLE
Degrees of freedom

### DIFF
--- a/R/cannedEstimationFunctions.R
+++ b/R/cannedEstimationFunctions.R
@@ -100,7 +100,7 @@ random.effect <- function(dat, incl.period.effect, outcome.type, alpha) {
 	}
 
 	n.clust <- length(unique(dat$clust))
-	df <- n.clust - 2 ## based on k-2 in Donner & Klar p.118
+	df <- 2*n.clust - 2 ## based on K-2 in Donner & Klar p.118
 	t <- qt(1 - alpha/2, df=df) * c(-1, 1)
 	est <- coef(summary(fit))["trt", ]
 	ci <- est["Estimate"] + t * est["Std. Error"]

--- a/man/power.sim.normal.Rd
+++ b/man/power.sim.normal.Rd
@@ -59,7 +59,7 @@ make.base.data(n.obs, n.clusters, cluster.size, n.periods)
   \item{n.obs}{ (for make.base.data() only) -- the total number of observations in the dataset. }
   \item{effect.size}{ effect size, specified on the GLM link scale }
   \item{alpha}{ desired type I error rate}
-  \item{n.clusters}{ number of clusters}
+  \item{n.clusters}{ number of clusters in each arm}
   \item{n.periods}{ number of periods of study}
   \item{cluster.size}{ either a numeric vector of length one or of length(n.clusters) defining the number of individuals in each cluster}
   \item{btw.clust.var}{the between-cluster variance}


### PR DESCRIPTION
The analytic power calculation is based on the number of clusters in each arm and the simulation is of the difference between the two arms; however, the degrees of freedom are based on the total number of clusters. Changing the degrees of freedom while keeping the n.clusters as the number in each arm makes the simulated power match the analytic power almost exactly.
