### PR TITLE
Fix issue cps.ma.count returns errors for examples from help file #221

### DIFF
--- a/R/confintCalc.R
+++ b/R/confintCalc.R
@@ -19,7 +19,7 @@ confintCalc <- function(alpha = alpha,
                         p.val = p.val,
                         nsim = nsim,
                         multi = FALSE) {
-  sig.val <-  ifelse(p.val < alpha, 1, 0)
+  sig.val <- sapply(p.val, function(x) ifelse(x < alpha, 1, 0))
   if (isTRUE(is.data.frame(sig.val)) ||
       isTRUE(is.matrix(sig.val))) {
     pval.power <- apply(sig.val, 2, FUN = sum)

--- a/R/cps.ma.binary.R
+++ b/R/cps.ma.binary.R
@@ -218,8 +218,8 @@ cps.ma.binary <- function(nsim = 1000,
   }
   
   # nsubjects must be whole numbers
-  if (sum(is.wholenumber(unlist(nsubjects)) == FALSE) != 0 ||
-      unlist(nsubjects) < 1) {
+  if (sum(is.wholenumber(unlist(nsubjects)) == FALSE) != 0 || 
+    any(unlist(nsubjects) < 1)) {
     stop("nsubjects must be positive integer values.")
   }
   


### PR DESCRIPTION
This pull request should fix the coercion into logical error that was due to the ifelse statement in the confintCalc.R