### PR TITLE
address situation when `nsubjects` is a vector of length > 1

### DIFF
--- a/R/cps.binary.R
+++ b/R/cps.binary.R
@@ -254,7 +254,7 @@ cps.binary = function(nsim = NULL,
   if (!is.wholenumber(nsim) || nsim < 1) {
     stop(paste0("NSIM", min1.warning))
   }
-  if (!is.wholenumber(nsubjects) || nsubjects < 1) {
+  if (any(!is.wholenumber(nsubjects) | nsubjects < 1)) {
     stop(paste0("NSUBJECTS", min1.warning))
   }
   if (!is.wholenumber(nclusters) || nclusters < 1) {


### PR DESCRIPTION
The `cps.binary` function gives an error when running the second example from the documentation. This occurs when `nsubjects` is a vector of length > 1.

This example

```
binary.sim2 <-
  cps.binary(
    nsim = 100,
    nsubjects = c(c(rep(10,9),100), rep(20,10)),
    nclusters = 10,
    p1 = 0.8,
    p2 = 0.5,
    sigma_b_sq = 1,
    sigma_b_sq2 = 1.2,
    alpha = 0.05,
    method = 'gee',
    allSimData = FALSE
)
```

outputs the following error:

```
Error in cps.binary(nsim = 100, nsubjects = c(c(rep(10, 9), 100), rep(20,  : 
  could not find function "cps.binary"
```

This PR addresses this by requiring all elements of `nsubjects` to meet the requirements.